### PR TITLE
Fix to use the latest GCM 9.6.1 change plugin id to streethawkpush

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.streethawk.push" version="1.8.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="streethawkpush" version="1.8.1" xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android">
 	<name>StreetHawkPush</name>
-	<description>StreetHawk SDK plugin for sending push notification to your applications</description>	    
+	<description>StreetHawk SDK plugin for sending push notification to your applications</description>
     <license>Apache 2.0</license>
-    <keywords>push,messaging,deeplinking,referral,analytics,geofencing,beacons,marketing,automation,organic growth,feeds</keywords>	
+    <keywords>push,messaging,deeplinking,referral,analytics,geofencing,beacons,marketing,automation,organic growth,feeds</keywords>
 	<platform name="android">
 		<config-file parent="/*" target="res/xml/config.xml">
 			<feature name="push">
@@ -12,10 +12,10 @@
 			</feature>
 		</config-file>
 
-		<framework src="com.google.android.gms:play-services-gcm:8.1.0" />
-			
+		<framework src="com.google.android.gms:play-services-gcm:9.6.1" />
+
 			<config-file parent="/manifest" target="AndroidManifest.xml">
-		  
+
 		   <permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"
 				android:protectionLevel="signature"/>
 			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" />
@@ -26,7 +26,7 @@
     		<uses-permission android:name="com.sonyericsson.home.permission.BROADCAST_BADGE" />
     		<uses-permission android:name="com.sec.android.provider.badge.permission.READ" />
     		<uses-permission android:name="com.sec.android.provider.badge.permission.WRITE" />
-		 
+
     		</config-file>
 		   <config-file parent="/manifest/application" target="AndroidManifest.xml">
 		   <activity
@@ -39,7 +39,7 @@
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
             </intent-filter>
         </service>
-        
+
          <receiver
             android:name="com.google.android.gms.gcm.GcmReceiver"
             android:permission="com.google.android.c2dm.permission.SEND" >
@@ -70,28 +70,28 @@
                 <action android:name="com.google.android.gms.iid.InstanceID"/>
             </intent-filter>
         </service>
-        
+
        <service
             android:name="com.streethawk.push.PushWrapper"
             android:enabled="true"
             android:exported="true" >
         </service>
-        
-		   </config-file>   
+
+		   </config-file>
 		<source-file src="src/android/streethawkpush.jar" target-dir="libs/"/>
 		<source-file src="src/android/PushWrapper.java" target-dir="src/com/streethawk"/>
 	</platform>
 	<platform name="ios">
-	
+
 		<!-- Enable preprocessor macro SH_FEATURE_NOTIFICATION -->
 		<hook type="after_plugin_install" src="src/ios/Script/enable_feature.js" />
 		<hook type="before_plugin_uninstall" src="src/ios/Script/disable_feature.js" />
-               
+
         <!-- Plugin native SDK -->
         <header-file src="src/ios/SDK/Notification/Internal/SHAlertSettingsViewController.h" />
         <source-file src="src/ios/SDK/Notification/Internal/SHAlertSettingsViewController.m" />
         <header-file src="src/ios/SDK/Notification/Internal/SHNotificationHandler.h" />
-        <source-file src="src/ios/SDK/Notification/Internal/SHNotificationHandler.m" />  
+        <source-file src="src/ios/SDK/Notification/Internal/SHNotificationHandler.m" />
         <header-file src="src/ios/SDK/Notification/Internal/SHSlideViewController.h" />
         <source-file src="src/ios/SDK/Notification/Internal/SHSlideViewController.m" />
         <header-file src="src/ios/SDK/Notification/Private/SHInteractiveButtons.h" />
@@ -110,20 +110,20 @@
         <source-file src="src/ios/SDK/Notification/Publish/SHApp+Notification.m" />
         <header-file src="src/ios/SDK/ThirdParty/CBAutoScrollLabel/CBAutoScrollLabel.h" />
         <source-file src="src/ios/SDK/ThirdParty/CBAutoScrollLabel/CBAutoScrollLabel.m" />
-        
-        <!-- Add frameworks -->       
+
+        <!-- Add frameworks -->
         <framework src="QuartzCore.framework" />
-        
+
 	</platform>
 	<info>
-	 StreetHawk Push plugin depends on StreetHawk core plugin. 
+	 StreetHawk Push plugin depends on StreetHawk core plugin.
 	 Install core plugin by using command
-	  
+
 	 cordova plugin add streethawkanalytics --variable APP_KEY=APP_KEY --variable URL_SCHEME=SCHEME
-	
-	Note: In the above command replace 
+
+	Note: In the above command replace
 	APP_KEY with your application's app_key.
 	SCHEME with your application's deeplink scheme.
-	
+
 	</info>
 </plugin>


### PR DESCRIPTION
Latest GCM
Change the plugin id to stop it from reinstalling on cordova prepare
